### PR TITLE
changes to work with new python syntax.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ We made following major changes in gem5:
 * modify "MESI_Two_Level" coherence protocol by adding 3 new transactions: SpecGetS, Expose, Validation
 * add a SpecBuffer at each L1, and a per-core SpecBuffer LLC
 
+## How to build the simulator?
+
+    $ scons build/X86/gem5.opt --default=X86 PROTOCOL=MESI_Two_Level
 
 ## How to run the simulator?
 

--- a/site_scons/site_init.py
+++ b/site_scons/site_init.py
@@ -48,25 +48,25 @@ try:
     # 0.98, and the second will fail for 0.98.0
     EnsureSConsVersion(0, 98)
     EnsureSConsVersion(0, 98, 1)
-except SystemExit, e:
-    print """
+except SystemExit as e:
+    print ("""
 For more details, see:
     http://gem5.org/Dependencies
-"""
+""")
     raise
 
 # pybind11 requires python 2.7
 try:
     EnsurePythonVersion(2, 7)
-except SystemExit, e:
-    print """
+except SystemExit as e:
+    print ("""
 You can use a non-default installation of the Python interpreter by
 rearranging your PATH so that scons finds the non-default 'python' and
 'python-config' first.
 
 For more details, see:
     http://gem5.org/wiki/index.php/Using_a_non-default_Python_installation
-"""
+""")
     raise
 
 sys.path[1:1] = extra_python_paths


### PR DESCRIPTION
It seems like modern versions of scons require use of the Python 3 compatible syntax. I have changed site_init.py to reflect this.

I also added the scons build command with the MESI_Two_Level coherence protocol specified to the README. I realize you already have documented the need for this protocol. That said, both a student and I wasted some time figuring out why gem5 wasn't building, plus one of your issues also mentions someone else running into the same problem. Therefore, I feel it might help to highlight it early in the README.